### PR TITLE
hotfix(gradle): corrigir mainClass e remover application aninhado

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,6 @@ tasks.test { useJUnitPlatform() }
 
 // a classe Main precisa existir neste pacote
 application {
-  application { mainClass.set("com.ada.commerce.controllers.cli.Main") }
+  application { mainClass.set("com.ada.commerce.Main") }
 }
 


### PR DESCRIPTION
Corrige execução da CLI via Gradle. Impacto: ./gradlew run volta a funcionar.