### PR TITLE
Feature/customer

### DIFF
--- a/src/main/java/com/ada/commerce/model/Customer.java
+++ b/src/main/java/com/ada/commerce/model/Customer.java
@@ -1,0 +1,80 @@
+package com.ada.commerce.model;
+
+import com.ada.commerce.model.vo.Document;
+import com.ada.commerce.model.vo.Email;
+
+import java.util.UUID;
+import java.time.Instant;
+import java.util.Objects;
+
+public class Customer {
+
+  private final String id;
+  private String name;
+  private final Document document;
+  private Email email;
+  private final Instant createdAt;
+  private boolean active;
+
+  public Customer(String name, Document document, Email email) {
+    this.id = UUID.randomUUID().toString();
+    this.name = name;
+    this.document = document;
+    this.email = email;
+    this.createdAt = Instant.now();
+    this.active = true;
+  }
+
+  public Customer(String id, String name, Document document, Email email, Instant createdAt, boolean active) {
+    if (name == null || name.isBlank()) throw new IllegalArgumentException("Nome inválido");
+    this.id = id;
+    this.name = name;
+    this.document = document;
+    this.email = email;
+    this.createdAt = createdAt;
+    this.active = active;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Document getDocument() {
+    return document;
+  }
+
+  public Email getEmail() {
+    return email;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public boolean isActive() {
+    return active;
+  }
+
+  public void updateName(String newName) {
+        if (newName == null || newName.isBlank()) throw new IllegalArgumentException("Nome inválido");
+        this.name = newName;
+    }
+
+  public void updateEmail(Email email) { this.email = email; }
+  public void deactivate() { this.active = false; }
+  public void activate() { this.active = true; }
+
+  @Override
+  public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Customer c)) return false;
+    return id.equals(c.id);
+  }
+
+  @Override
+  public int hashCode(){ return Objects.hash(id);}
+}

--- a/src/main/java/com/ada/commerce/model/Customer.java
+++ b/src/main/java/com/ada/commerce/model/Customer.java
@@ -1,7 +1,7 @@
 package com.ada.commerce.model;
 
 import com.ada.commerce.model.vo.Document;
-import com.ada.commerce.model.vo.Email;
+import com.ada.commerce.model.vo.ValidarEmail;
 
 import java.util.UUID;
 import java.time.Instant;
@@ -12,11 +12,11 @@ public class Customer {
   private final String id;
   private String name;
   private final Document document;
-  private Email email;
+  private ValidarEmail email;
   private final Instant createdAt;
   private boolean active;
 
-  public Customer(String name, Document document, Email email) {
+  public Customer(String name, Document document, ValidarEmail email) {
     this.id = UUID.randomUUID().toString();
     this.name = name;
     this.document = document;
@@ -25,7 +25,7 @@ public class Customer {
     this.active = true;
   }
 
-  public Customer(String id, String name, Document document, Email email, Instant createdAt, boolean active) {
+  public Customer(String id, String name, Document document, ValidarEmail email, Instant createdAt, boolean active) {
     if (name == null || name.isBlank()) throw new IllegalArgumentException("Nome inválido");
     this.id = id;
     this.name = name;
@@ -47,7 +47,7 @@ public class Customer {
     return document;
   }
 
-  public Email getEmail() {
+  public ValidarEmail getEmail() {
     return email;
   }
 
@@ -64,7 +64,7 @@ public class Customer {
         this.name = newName;
     }
 
-  public void updateEmail(Email email) { this.email = email; }
+  public void updateEmail(ValidarEmail email) { this.email = email; }
   public void deactivate() { this.active = false; }
   public void activate() { this.active = true; }
 

--- a/src/main/java/com/ada/commerce/model/exception/DuplicateDocumentException.java
+++ b/src/main/java/com/ada/commerce/model/exception/DuplicateDocumentException.java
@@ -1,0 +1,7 @@
+package com.ada.commerce.model.exception;
+
+public class DuplicateDocumentException extends RuntimeException {
+  public DuplicateDocumentException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/ada/commerce/model/exception/InvalidDocumentException.java
+++ b/src/main/java/com/ada/commerce/model/exception/InvalidDocumentException.java
@@ -1,0 +1,6 @@
+package com.ada.commerce.model.exception;
+
+public class InvalidDocumentException extends Throwable {
+  public InvalidDocumentException(String message) { super(message); }
+  public InvalidDocumentException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/com/ada/commerce/model/exception/NotFoundException.java
+++ b/src/main/java/com/ada/commerce/model/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.ada.commerce.model.exception;
+
+public class NotFoundException extends RuntimeException {
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/ada/commerce/model/vo/Document.java
+++ b/src/main/java/com/ada/commerce/model/vo/Document.java
@@ -1,0 +1,76 @@
+package com.ada.commerce.model.vo;
+
+import com.ada.commerce.model.exception.InvalidDocumentException;
+
+import java.util.Locale;
+import java.util.Objects;
+
+
+public final class Document {
+  private final String value;
+  private final Type type;
+
+  public enum Type { CPF, CNPJ }
+
+  public Document(String raw, Type type) throws InvalidDocumentException {
+    if (raw == null) throw new InvalidDocumentException("Documento nulo");
+    this.type = Objects.requireNonNull(type, "type");
+    DocumentValidator validator = validatorFor(type);
+
+    if (!validator.isValid(raw)) {
+      throw new InvalidDocumentException("Documento inválido para tipo " + type);
+    }
+    String cleaned = raw.replaceAll("\\D", "");
+    if (type == Type.CPF && cleaned.length() != 11) throw new InvalidDocumentException("CPF com tamanho inválido");
+    if (type == Type.CNPJ && cleaned.length() != 14) throw new InvalidDocumentException("CNPJ com tamanho inválido");
+
+    this.value = cleaned;
+  }
+
+  private DocumentValidator validatorFor(Type type) {
+    return switch (type) {
+      case CPF -> new ValidarCPF();
+      case CNPJ -> new ValidarCNPJ();
+    };
+  }
+
+  public String value() { return value; }
+
+  public Type type() { return type; }
+
+  public String formatted() {
+    if (type == Type.CPF && value.length() == 11) {
+      return String.format("%s.%s.%s-%s",
+        value.substring(0,3),
+        value.substring(3,6),
+        value.substring(6,9),
+        value.substring(9));
+    } else if (type == Type.CNPJ && value.length() == 14) {
+      return String.format("%s.%s.%s/%s-%s",
+        value.substring(0,2),
+        value.substring(2,5),
+        value.substring(5,8),
+        value.substring(8,12),
+        value.substring(12));
+    }
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof Document)) return false;
+    Document d = (Document) o;
+    return value.equals(d.value) && type == d.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, type);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(Locale.ROOT, "%s(%s)", formatted(), type);
+  }
+}

--- a/src/main/java/com/ada/commerce/model/vo/DocumentValidator.java
+++ b/src/main/java/com/ada/commerce/model/vo/DocumentValidator.java
@@ -1,0 +1,10 @@
+package com.ada.commerce.model.vo;
+
+public interface DocumentValidator {
+  /**
+   * Valida o valor (pode ser formatado ou só dígitos).
+   * @param value entrada do usuário (ex: "123.456.789-09" ou "12345678909")
+   * @return true se válido
+   */
+  boolean isValid(String value);
+}

--- a/src/main/java/com/ada/commerce/model/vo/Email.java
+++ b/src/main/java/com/ada/commerce/model/vo/Email.java
@@ -1,0 +1,25 @@
+package com.ada.commerce.model.vo;
+
+import com.ada.commerce.model.exception.InvalidDocumentException;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public final class Email {
+  private static final Pattern SIMPLE = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+  private final String value;
+
+  public Email(String value) throws InvalidDocumentException {
+    if (value == null || !SIMPLE.matcher(value).matches())
+      throw new InvalidDocumentException("E-mail inválido");
+    this.value = value.toLowerCase();
+  }
+
+  public String value(){ return value; }
+
+  @Override public boolean equals(Object o){ return o instanceof Email && value.equals(((Email)o).value); }
+
+  @Override public int hashCode(){ return Objects.hash(value); }
+
+  @Override public String toString(){ return value; }
+}

--- a/src/main/java/com/ada/commerce/model/vo/ValidarCNPJ.java
+++ b/src/main/java/com/ada/commerce/model/vo/ValidarCNPJ.java
@@ -1,0 +1,44 @@
+package com.ada.commerce.model.vo;
+
+import java.util.Objects;
+
+public class ValidarCNPJ implements DocumentValidator {
+
+  private static final String CNPJ_FORMATTED_REGEX = "^\\d{2}\\.\\d{3}\\.\\d{3}/\\d{4}-\\d{2}$";
+  private static final String ONLY_DIGITS = "^\\d{14}$";
+
+  @Override
+  public boolean isValid(String valor) {
+    if (valor == null) return false;
+    String v = valor.trim();
+    if (!v.matches(CNPJ_FORMATTED_REGEX) && !v.matches(ONLY_DIGITS)) return false;
+
+    String cnpj = v.replaceAll("\\D", "");
+    if (cnpj.length() != 14) return false;
+    if (cnpj.chars().distinct().count() == 1) return false;
+
+    int dig1 = calcularDigito(cnpj, 12, new int[]{5,4,3,2,9,8,7,6,5,4,3,2});
+    int dig2 = calcularDigito(cnpj, 13, new int[]{6,5,4,3,2,9,8,7,6,5,4,3,2});
+
+    int expected1 = Character.getNumericValue(cnpj.charAt(12));
+    int expected2 = Character.getNumericValue(cnpj.charAt(13));
+    return dig1 == expected1 && dig2 == expected2;
+  }
+
+  private int calcularDigito(String cnpj, int length, int[] pesos) {
+    int soma = 0;
+    for (int i = 0; i < length; i++) {
+      soma += Character.getNumericValue(cnpj.charAt(i)) * pesos[i];
+    }
+    int resto = soma % 11;
+    return (resto < 2) ? 0 : 11 - resto;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof ValidarCNPJ;
+  }
+
+  @Override
+  public int hashCode() { return Objects.hash("ValidarCNPJ"); }
+}

--- a/src/main/java/com/ada/commerce/model/vo/ValidarCPF.java
+++ b/src/main/java/com/ada/commerce/model/vo/ValidarCPF.java
@@ -1,0 +1,43 @@
+package com.ada.commerce.model.vo;
+
+import java.util.Objects;
+
+public class ValidarCPF implements DocumentValidator {
+  private static final String CPF_FORMATTED_REGEX = "^\\d{3}\\.\\d{3}\\.\\d{3}-\\d{2}$";
+  private static final String ONLY_DIGITS = "^\\d{11}$";
+
+  @Override
+  public boolean isValid(String valor) {
+    if (valor == null) return false;
+    String v = valor.trim();
+    if (!v.matches(CPF_FORMATTED_REGEX) && !v.matches(ONLY_DIGITS)) return false;
+
+    String cpf = v.replaceAll("\\D", "");
+    if (cpf.length() != 11) return false;
+    if (cpf.chars().distinct().count() == 1) return false; // sequências repetidas inválidas
+
+    int dig1 = calcularDigito(cpf, 9, 10);
+    int dig2 = calcularDigito(cpf, 10, 11);
+
+    int expected1 = Character.getNumericValue(cpf.charAt(9));
+    int expected2 = Character.getNumericValue(cpf.charAt(10));
+    return dig1 == expected1 && dig2 == expected2;
+  }
+
+  private int calcularDigito(String cpf, int length, int pesoInicial) {
+    int soma = 0;
+    for (int i = 0; i < length; i++) {
+      soma += Character.getNumericValue(cpf.charAt(i)) * (pesoInicial - i);
+    }
+    int resto = soma % 11;
+    return (resto < 2) ? 0 : 11 - resto;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof ValidarCPF;
+  }
+
+  @Override
+  public int hashCode() { return Objects.hash("ValidarCPF"); }
+}

--- a/src/main/java/com/ada/commerce/model/vo/ValidarEmail.java
+++ b/src/main/java/com/ada/commerce/model/vo/ValidarEmail.java
@@ -5,11 +5,11 @@ import com.ada.commerce.model.exception.InvalidDocumentException;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
-public final class Email {
-  private static final Pattern SIMPLE = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
+public final class ValidarEmail {
+  private static final Pattern SIMPLE = Pattern.compile("^[\\\\w!#$%&’*+/=?`{|}~^.-]+(?:\\\\.[\\\\w!#$%&’*+/=?`{|}~^.-]+)*@(?:[a-zA-Z0-9-]+\\\\.)+[a-zA-Z]{2,6}$");
   private final String value;
 
-  public Email(String value) throws InvalidDocumentException {
+  public ValidarEmail(String value) throws InvalidDocumentException {
     if (value == null || !SIMPLE.matcher(value).matches())
       throw new InvalidDocumentException("E-mail inválido");
     this.value = value.toLowerCase();
@@ -17,7 +17,7 @@ public final class Email {
 
   public String value(){ return value; }
 
-  @Override public boolean equals(Object o){ return o instanceof Email && value.equals(((Email)o).value); }
+  @Override public boolean equals(Object o){ return o instanceof ValidarEmail && value.equals(((ValidarEmail)o).value); }
 
   @Override public int hashCode(){ return Objects.hash(value); }
 


### PR DESCRIPTION

This pull request introduces a new domain model for customer management, focusing on robust value objects for document and email validation, as well as custom exceptions for error handling. The changes lay the groundwork for reliable customer data processing and validation.

### Domain Model and Value Objects

* Added the `Customer` entity class, encapsulating customer attributes and behaviors such as activation, deactivation, and updating name/email, with validation logic for name and email. (`src/main/java/com/ada/commerce/model/Customer.java`)
* Implemented the immutable `Document` value object with strict validation for CPF and CNPJ formats, leveraging dedicated validators and providing formatted output. (`src/main/java/com/ada/commerce/model/vo/Document.java`)
* Added `ValidarEmail` value object for email validation using regex, ensuring only valid emails are accepted. (`src/main/java/com/ada/commerce/model/vo/ValidarEmail.java`)

### Validation Strategy

* Introduced the `DocumentValidator` interface and provided concrete implementations for CPF (`ValidarCPF`) and CNPJ (`ValidarCNPJ`), encapsulating the validation algorithms for each document type. (`src/main/java/com/ada/commerce/model/vo/DocumentValidator.java`, `ValidarCPF.java`, `ValidarCNPJ.java`) [[1]](diffhunk://#diff-70df75e72ebe3adaaebd1e8fac3d82fdbba0a6b2c403ca79b2c1a4a643bfa3bfR1-R10) [[2]](diffhunk://#diff-44b022ad68ab552a5b6b8daf75fa4f678aac0b5cd96b427d67360ba1922eda00R1-R43) [[3]](diffhunk://#diff-1fb6610f46eb998cd5dd5c851df57b41d5eca7594ca7ed283ae41acc1fb4e339R1-R44)

### Exception Handling

* Added custom exceptions: `InvalidDocumentException`, `DuplicateDocumentException`, and `NotFoundException` to support domain-specific error handling for invalid documents, duplicates, and not found scenarios. (`src/main/java/com/ada/commerce/model/exception/InvalidDocumentException.java`, `DuplicateDocumentException.java`, `NotFoundException.java`) [[1]](diffhunk://#diff-68688b3c4584d2adc862c53764f90d1dcd69f44083d808d0cb3fa7bdc326f22dR1-R6) [[2]](diffhunk://#diff-fcb8671c02488004993db102532ed857aa539501b1daca7f45d34a3252f98b65R1-R7) [[3]](diffhunk://#diff-6de89db62afb0e49678a3f393527a9c9497ae606cf74367ba4887a975504d109R1-R7)
